### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,19 @@
 # libemuls
 
-`libemuls` is a framework, written in Rust, for writing retro gaming system emulators.
+`libemuls` is my personal experimental project in the retrogaming emulators field.
 
-Although it provides binaries for emulating systems, it's not intended for end-users, instead, for developers interested in writing emulators.
+Since the purpose it to (at least currently) be a dumping ground for my experiments, it's of no value to end users; some ideas may be of general interest to developers.
 
-Table of contents:
+Subjects I've explored until now:
 
-- [libemuls](#libemuls)
-  - [Architecture](#architecture)
-    - [Software support](#software-support)
-  - [Software engineering considerations](#software-engineering-considerations)
-    - [Clarity](#clarity)
-    - [Next developments](#next-developments)
-  - [Current support, and running an emulator](#current-support-and-running-an-emulator)
-  - [Current packages](#current-packages)
-    - [Packages naming](#packages-naming)
-  - [Documentation](#documentation)
+- CHIP-8 emulation
+  - completed the unextended instructions set, a few extensions implemented
+  - functioning emulator, with an SDL interface
+- Rust programming
+- Generic emulation interfaces, with strong components separation
+- Benchmarking different multithreading architectures for high-performance systems, including lockless implementations
+- Automated generation of CPU instructions fetch/decoding/execution, starting from instructions metadata
 
-## Architecture
+My next subject in line is implementing a WASM interface.
 
-The architecture is founded on separation of concerns, which is expressed in two areas:
-
-- in terms of tiers: by separating the frontend from the backend, it makes it simple to write different frontends (e.g. SDL, WASM...)
-- in terms of components: each hardware component is encapsulated in a library, so that an emulator can be written by putting together libraries; for example, a Commodore 64 can be emulated by wiring together separate libraries for the MOS 6510, the VIC-II, and the SID 8580 (of course, it's not implied that "wiring together" is a simple task).
-
-### Software support
-
-Since the project's target is not gaming in itself, compatibility with games has relatively little importance. A base number of programs (games) will be supported for each platform, but the extra time required to debug obscure, undocumented behaviors, will be rather spent for researching/developing a new library.
-
-Compatibility improvement contributions are always welcome, nonetheless.
-
-## Software engineering considerations
-
-### Clarity
-
-Since this is essentially an educative project, it's founded on clarity in every aspect, from the documentation, to the testing, down to the SCM metadata (history).
-
-Due to `system-chip_8` being primarily an exploration, it doesn't have any automated tests, however, the other libraries are specified and verified through test suites.
-
-### Next developments
-
-The Game Boy system is currently under development.
-
-The component currently developed is the CPU. Almost all the instructions have been implemented, along with a large test suite; both are generated from [a metadata file](../master/component_sharp_lr35902/extra/data/instructions.json) by [a generator](../master/component_sharp_lr35902/extra/generate_instruction_templates).
-
-## Current support, and running an emulator
-
-Currently, a basic CHIP-8 emulator with SDL frontend is provided.
-
-It can be run from the project root, with `cargo run --bin emu-chip_8-sdl -- /path/to/rom`; help is provided via `cargo run --bin emu-chip_8-sdl -- --help`.
-
-In order to quickly run a test game:
-
-```sh
-cargo run --bin emu-chip_8-sdl -- <(curl -L 'https://github.com/JohnEarnest/chip8Archive/blob/master/roms/flightrunner.ch8?raw=true')
-```
-
-Keys are `W`, `A`, `S`, `D`.
-
-## Current packages
-
-The project is currently composed of the following packages:
-
-- `emu-chip_8-sdl`: SDL CHIP-8 full emulator
-- `system-chip_8`: CHIP-8 (single-component) system
-- `frontend-sdl`: SDL frontend implementation
-- `interfaces-frontend`: Frontend interfaces
-
-### Packages naming
-
-- full emulators: `emu-<system>-<frontend>`, e.g. `emu-chip_8-sdl`
-- systems: `system-<name>`, e.g. `system-commodore_64`
-- components: `component-<name>`, e.g. `system-chip_8`
-- periperals: `peripheral-<name>`, e.g. `peripheral-tv_pal`
-- frontends: `frontend-<name>`, e.g. `frontend-sdl`
-- interfaes: `interface-<package_type>`, e.g. `interfaces-frontend`
-
-## Documentation
-
-The code comments and documentation are intended to be expressive and thorough; the specifications are defined through the test suites.
-
-Documentation for the Game Boy project will start once the design is stable.
-
-The [GitHub project wiki](../../wiki) includes additional information.
+The [GitHub project wiki](../../wiki) has additional information.


### PR DESCRIPTION
Reduced the scope to be "just" a dumping ground for emulation experiments.

The architectural sections have been moved to the wiki.